### PR TITLE
[TASK] Add redirect option for after login/logout

### DIFF
--- a/Classes/Flowpack/Neos/FrontendLogin/Controller/AuthenticationController.php
+++ b/Classes/Flowpack/Neos/FrontendLogin/Controller/AuthenticationController.php
@@ -26,7 +26,14 @@ class AuthenticationController extends AbstractAuthenticationController {
 	 */
 	public function logoutAction() {
 		parent::logoutAction();
-		$this->redirect('index');
+
+		$uri = $this->request->getInternalArgument('__redirectAfterLogoutUri');
+
+		if (empty($uri)) {
+			$this->redirect('index');
+		} else {
+			$this->redirectToUri($uri);
+		}
 	}
 
 	/**
@@ -34,7 +41,13 @@ class AuthenticationController extends AbstractAuthenticationController {
 	 * @return string
 	 */
 	protected function onAuthenticationSuccess(ActionRequest $originalRequest = NULL) {
-		$this->redirect('index');
+		$uri = $this->request->getInternalArgument('__redirectAfterLoginUri');
+
+		if (empty($uri)) {
+			$this->redirect('index');
+		} else {
+			$this->redirectToUri($uri);
+		}
 	}
 
 	/**

--- a/Configuration/NodeTypes.LoginForm.yaml
+++ b/Configuration/NodeTypes.LoginForm.yaml
@@ -5,5 +5,31 @@
   superTypes:
     'TYPO3.Neos:Plugin': TRUE
   ui:
-    label: 'Frontend login form'
+    label: i18n
     icon: 'icon-key'
+    inspector:
+      groups:
+        pluginSettings:
+          label: i18n
+
+  properties:
+    redirectAfterLogin:
+      type: reference
+      ui:
+        label: i18n
+        reloadIfChanged: false
+        inspector:
+          group: pluginSettings
+          editorOptions:
+            nodeTypes:
+              - 'TYPO3.Neos:Document'
+    redirectAfterLogout:
+      type: reference
+      ui:
+        label: i18n
+        reloadIfChanged: false
+        inspector:
+          group: pluginSettings
+          editorOptions:
+            nodeTypes:
+              - 'TYPO3.Neos:Document'

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -16,3 +16,8 @@ TYPO3:
     typoScript:
       autoInclude:
         'Flowpack.Neos.FrontendLogin': TRUE
+
+    userInterface:
+      translation:
+        autoInclude:
+          'Flowpack.Neos.FrontendLogin': ['NodeTypes/*']

--- a/Resources/Private/Translations/en/NodeTypes/LoginForm.xlf
+++ b/Resources/Private/Translations/en/NodeTypes/LoginForm.xlf
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+	<file original="" product-name="Flowpack.Neos.FrontendLogin" source-language="en" datatype="plaintext">
+		<body>
+			<trans-unit id="ui.label" xml:space="preserve">
+				<source>Frontend login form</source>
+			</trans-unit>
+			<trans-unit id="groups.pluginSettings" xml:space="preserve">
+				<source>Login Settings</source>
+			</trans-unit>
+			<trans-unit id="properties.redirectAfterLogin" xml:space="preserve">
+				<source>Page after login</source>
+			</trans-unit>
+			<trans-unit id="properties.redirectAfterLogout" xml:space="preserve">
+				<source>Page after logout</source>
+			</trans-unit>
+		</body>
+	</file>
+</xliff>

--- a/Resources/Private/TypoScript/NodeTypes/LoginForm.ts2
+++ b/Resources/Private/TypoScript/NodeTypes/LoginForm.ts2
@@ -5,4 +5,12 @@ prototype(Flowpack.Neos.FrontendLogin:LoginForm) < prototype(TYPO3.Neos:Plugin) 
 	package = 'Flowpack.Neos.FrontendLogin'
 	controller = 'Authentication'
 	action = 'index'
+
+	redirectAfterLoginUri = TYPO3.Neos:NodeUri {
+		node = ${q(node).property('redirectAfterLogin')}
+	}
+
+	redirectAfterLogoutUri = TYPO3.Neos:NodeUri {
+		node = ${q(node).property('redirectAfterLogout')}
+	}
 }


### PR DESCRIPTION
This change adds two properties to LoginForm node type. Both are of type reference of TYPO3.Neos:Document.

Purpose:
You can set a page to redirect to after successful login or logout operation.
