### PR TITLE
TASK: Adjust requestPattern settings to new syntax

### DIFF
--- a/Classes/Flowpack/Neos/FrontendLogin/Security/NeosRequestPattern.php
+++ b/Classes/Flowpack/Neos/FrontendLogin/Security/NeosRequestPattern.php
@@ -14,31 +14,18 @@ use TYPO3\Flow\Security\RequestPatternInterface;
  */
 class NeosRequestPattern implements RequestPatternInterface {
 
-	const PATTERN_BACKEND = 'backend';
-	const PATTERN_FRONTEND = 'frontend';
-
 	/**
-	 * @var boolean
+	 * @var array
 	 */
-	protected $shouldMatchBackend = TRUE;
+	protected $options;
 
 	/**
-	 * Returns the set pattern
+	 * Expects options in the form array('matchFrontend' => TRUE/FALSE)
 	 *
-	 * @return string The set pattern
+	 * @param array $options
 	 */
-	public function getPattern() {
-		return $this->shouldMatchBackend ? self::PATTERN_BACKEND : self::PATTERN_FRONTEND;
-	}
-
-	/**
-	 * Sets the pattern (match) configuration
-	 *
-	 * @param object $pattern The pattern (match) configuration
-	 * @return void
-	 */
-	public function setPattern($pattern) {
-		$this->shouldMatchBackend = ($pattern === self::PATTERN_FRONTEND) ? FALSE : TRUE;
+	public function __construct(array $options) {
+		$this->options = $options;
 	}
 
 	/**
@@ -51,9 +38,10 @@ class NeosRequestPattern implements RequestPatternInterface {
 		if (!$request instanceof ActionRequest) {
 			return FALSE;
 		}
+		$shouldMatchFrontend = isset($this->options['matchFrontend']) && $this->options['matchFrontend'] === true;
 		$requestPath = $request->getHttpRequest()->getUri()->getPath();
 		$requestPathMatchesBackend = substr($requestPath, 0, 5) === '/neos' || strpos($requestPath, '@') !== FALSE;
-		return $this->shouldMatchBackend === $requestPathMatchesBackend;
+		return $shouldMatchFrontend !== $requestPathMatchesBackend;
 	}
 
 }

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -6,11 +6,15 @@ TYPO3:
         providers:
           'Typo3BackendProvider':
             requestPatterns:
-              'Flowpack\Neos\FrontendLogin\Security\NeosRequestPattern': 'backend'
+              'Flowpack.Neos.FrontendLogin:NeosBackend':
+                pattern: 'Flowpack\Neos\FrontendLogin\Security\NeosRequestPattern'
           'Flowpack.Neos.FrontendLogin:Frontend':
             provider: 'PersistedUsernamePasswordProvider'
             requestPatterns:
-              'Flowpack\Neos\FrontendLogin\Security\NeosRequestPattern': 'frontend'
+              'Flowpack.Neos.FrontendLogin:NeosFrontend':
+                pattern: 'Flowpack\Neos\FrontendLogin\Security\NeosRequestPattern'
+                patternOptions:
+                  matchFrontend: TRUE
 
   Neos:
     typoScript:


### PR DESCRIPTION
Adjusts the requestPattern configuration & `NeosRequestPattern` to the new
syntax introduced with neos/flow-development-collection#130

Related: FLOW-412
