### PR TITLE
FEATURE: Display authentication error on login form

### DIFF
--- a/Classes/Flowpack/Neos/FrontendLogin/Controller/AuthenticationController.php
+++ b/Classes/Flowpack/Neos/FrontendLogin/Controller/AuthenticationController.php
@@ -6,13 +6,33 @@ namespace Flowpack\Neos\FrontendLogin\Controller;
  *                                                                             */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Error\Error;
 use TYPO3\Flow\Mvc\ActionRequest;
 use TYPO3\Flow\Security\Authentication\Controller\AbstractAuthenticationController;
+use TYPO3\Flow\Security\Exception\AuthenticationRequiredException;
 
 /**
  * Controller for displaying a login/logout form and authenticating/logging out "frontend users"
  */
 class AuthenticationController extends AbstractAuthenticationController {
+
+	/**
+	 * @var \TYPO3\Flow\I18n\Translator
+	 * @Flow\Inject
+	 */
+	protected $translator;
+
+	/**
+	 * @Flow\InjectConfiguration(package="Flowpack.Neos.FrontendLogin", path="translation.packageKey")
+	 * @var string
+	 */
+	protected $translationPackageKey;
+
+	/**
+	 * @Flow\InjectConfiguration(package="Flowpack.Neos.FrontendLogin", path="translation.sourceName")
+	 * @var string
+	 */
+	protected $translationSourceName;
 
 	/**
 	 * @return void
@@ -48,6 +68,20 @@ class AuthenticationController extends AbstractAuthenticationController {
 		} else {
 			$this->redirectToUri($uri);
 		}
+	}
+
+	protected function onAuthenticationFailure(AuthenticationRequiredException $exception = null) {
+		$title = $this->getTranslationById('authentication.failure.title');
+		$message = $this->getTranslationById('authentication.failure.message');
+		$this->flashMessageContainer->addMessage(new Error($message, ($exception === null ? 1496914553 : $exception->getCode()), array(), $title));
+	}
+
+	/**
+	 * @param string $labelId Key to use for finding translation
+	 * @return string Translated message or NULL on failure
+	 */
+	protected function getTranslationById($labelId) {
+		return $this->translator->translateById($labelId, array(), null, null, $this->translationSourceName, $this->translationPackageKey);
 	}
 
 	/**

--- a/Classes/Flowpack/Neos/FrontendLogin/Controller/AuthenticationController.php
+++ b/Classes/Flowpack/Neos/FrontendLogin/Controller/AuthenticationController.php
@@ -70,6 +70,13 @@ class AuthenticationController extends AbstractAuthenticationController {
 		}
 	}
 
+
+	/**
+	 * Create translated FlashMessage and add it to flashMessageContainer
+	 *
+	 * @param ActionRequest $originalRequest The request that was intercepted by the security framework, NULL if there was none
+	 * @return string
+	 */
 	protected function onAuthenticationFailure(AuthenticationRequiredException $exception = null) {
 		$title = $this->getTranslationById('authentication.failure.title');
 		$message = $this->getTranslationById('authentication.failure.message');
@@ -77,6 +84,8 @@ class AuthenticationController extends AbstractAuthenticationController {
 	}
 
 	/**
+	 * Get translation by label id for configured source name and package key
+	 *
 	 * @param string $labelId Key to use for finding translation
 	 * @return string Translated message or NULL on failure
 	 */

--- a/Classes/Flowpack/Neos/FrontendLogin/Controller/AuthenticationController.php
+++ b/Classes/Flowpack/Neos/FrontendLogin/Controller/AuthenticationController.php
@@ -6,7 +6,7 @@ namespace Flowpack\Neos\FrontendLogin\Controller;
  *                                                                             */
 
 use TYPO3\Flow\Annotations as Flow;
-use TYPO3\Flow\Error\Error;
+use TYPO3\Flow\Error\Message;
 use TYPO3\Flow\Mvc\ActionRequest;
 use TYPO3\Flow\Security\Authentication\Controller\AbstractAuthenticationController;
 use TYPO3\Flow\Security\Exception\AuthenticationRequiredException;
@@ -58,7 +58,7 @@ class AuthenticationController extends AbstractAuthenticationController {
 
 	/**
 	 * @param ActionRequest $originalRequest The request that was intercepted by the security framework, NULL if there was none
-	 * @return string
+	 * @return void
 	 */
 	protected function onAuthenticationSuccess(ActionRequest $originalRequest = NULL) {
 		$uri = $this->request->getInternalArgument('__redirectAfterLoginUri');
@@ -74,13 +74,13 @@ class AuthenticationController extends AbstractAuthenticationController {
 	/**
 	 * Create translated FlashMessage and add it to flashMessageContainer
 	 *
-	 * @param ActionRequest $originalRequest The request that was intercepted by the security framework, NULL if there was none
-	 * @return string
+	 * @param AuthenticationRequiredException $exception
+	 * @return void
 	 */
 	protected function onAuthenticationFailure(AuthenticationRequiredException $exception = null) {
 		$title = $this->getTranslationById('authentication.failure.title');
 		$message = $this->getTranslationById('authentication.failure.message');
-		$this->flashMessageContainer->addMessage(new Error($message, ($exception === null ? 1496914553 : $exception->getCode()), array(), $title));
+		$this->addFlashMessage($message, $title, Message::SEVERITY_ERROR, [], $exception === null ? 1496914553 : $exception->getCode());
 	}
 
 	/**
@@ -90,7 +90,7 @@ class AuthenticationController extends AbstractAuthenticationController {
 	 * @return string Translated message or NULL on failure
 	 */
 	protected function getTranslationById($labelId) {
-		return $this->translator->translateById($labelId, array(), null, null, $this->translationSourceName, $this->translationPackageKey);
+		return $this->translator->translateById($labelId, [], null, null, $this->translationSourceName, $this->translationPackageKey);
 	}
 
 	/**

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -21,3 +21,10 @@ TYPO3:
       translation:
         autoInclude:
           'Flowpack.Neos.FrontendLogin': ['NodeTypes/*']
+
+Flowpack:
+  Neos:
+    FrontendLogin:
+      translation:
+        packageKey: 'Flowpack.Neos.FrontendLogin'
+        sourceName: 'Main'

--- a/Resources/Private/Templates/Authentication/Index.html
+++ b/Resources/Private/Templates/Authentication/Index.html
@@ -16,6 +16,8 @@
 							</f:form>
 						</f:then>
 						<f:else>
+							<f:flashMessages severity="Error" />
+
 							<f:form action="authenticate" method="post" class="form-horizontal clearfix" additionalAttributes="{role:'form'}">
 								<div class="form-group">
 									<label for="typo3-neosdemotypo3org-username" class="col-lg-4 control-label">Username:</label>

--- a/Resources/Private/Translations/de/Main.xlf
+++ b/Resources/Private/Translations/de/Main.xlf
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+	<file original="" product-name="Flowpack.Neos.FrontendLogin" source-language="en" target-language="de" datatype="plaintext">
+		<body>
+			<trans-unit id="authentication.failure.title" xml:space="preserve">
+				<source>Login failed!</source>
+				<target state="translated">Anmeldung fehlgeschlagen!</target>
+			</trans-unit>
+            <trans-unit id="authentication.failure.message" xml:space="preserve">
+				<source>With the given credentials the login could not be performed successfully.</source>
+				<target state="translated">Die Anmeldung konnte mit den gegebenen Zugangsdaten nicht erfolgreich durchgeführt werden.</target>
+			</trans-unit>
+		</body>
+	</file>
+</xliff>

--- a/Resources/Private/Translations/de/Main.xlf
+++ b/Resources/Private/Translations/de/Main.xlf
@@ -8,7 +8,7 @@
 			</trans-unit>
             <trans-unit id="authentication.failure.message" xml:space="preserve">
 				<source>With the given credentials the login could not be performed successfully.</source>
-				<target state="translated">Die Anmeldung konnte mit den gegebenen Zugangsdaten nicht erfolgreich durchgeführt werden.</target>
+				<target state="translated">Die Anmeldung konnte mit den eingegebenen Zugangsdaten nicht erfolgreich durchgeführt werden.</target>
 			</trans-unit>
 		</body>
 	</file>

--- a/Resources/Private/Translations/de/NodeTypes/LoginForm.xlf
+++ b/Resources/Private/Translations/de/NodeTypes/LoginForm.xlf
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-	<file original="" product-name="Flowpack.Neos.FrontendLogin" source-language="en" datatype="plaintext">
+	<file original="" product-name="Flowpack.Neos.FrontendLogin" source-language="en" target-language="de" datatype="plaintext">
 		<body>
 			<trans-unit id="ui.label" xml:space="preserve" approved="yes">
 				<source>Frontend login form</source>

--- a/Resources/Private/Translations/en/Main.xlf
+++ b/Resources/Private/Translations/en/Main.xlf
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+	<file original="" product-name="Flowpack.Neos.FrontendLogin" source-language="en" datatype="plaintext">
+		<body>
+			<trans-unit id="authentication.failure.title" xml:space="preserve">
+				<source>Login failed!</source>
+			</trans-unit>
+			<trans-unit id="authentication.failure.message" xml:space="preserve">
+				<source>With the given credentials the login could not be performed successfully.</source>
+			</trans-unit>
+		</body>
+	</file>
+</xliff>


### PR DESCRIPTION
The login form is missing error message for failed login.
This change adds simple FlashMessageViewHelper in index template, for showing the error message.
The translated error message is created `onAuthenticationFailure ` inside AuthenticationController.
The used translation file and package can be configured via `Settings.yaml`.