### PR TITLE
TASK: Add empty role definition for FrontendLogin:User

### DIFF
--- a/Configuration/Policy.yaml
+++ b/Configuration/Policy.yaml
@@ -13,3 +13,5 @@ roles:
           # Grant any user access to the FrontendLoginLoginForm plugin
         privilegeTarget: 'Flowpack.Neos.FrontendLogin:LoginForm'
         permission: GRANT
+
+  'Flowpack.Neos.FrontendLogin:User':


### PR DESCRIPTION
The shipped template requires the role
Flowpack.Neos.FrontendLogin:User to be present which is not defined
and so leads to an exception.