### PR TITLE
TASK: Remove PHP version from composer dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,6 @@
     "description": "Neos plugin demonstrating a simple frontend login",
     "license": "MIT",
     "require": {
-        "php": "^7.2",
         "neos/neos": "^5.0 || ^7.0 || dev-master"
     },
     "autoload": {


### PR DESCRIPTION
The minimal required php version of all supprted neos versions is higher than the old constraint and the constraint effectively forbade PHP 8

Resolves: #33
Replaces: #31