### PR TITLE
Fix templatePathAndFilename and requestFilter in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ add the following configuration there:
 -
   requestFilter: 'isPackage("Flowpack.Neos.FrontendLogin") && isController("Authentication") && isAction("index")'
   options:
-    templatePathAndFilename: 'resource://Acme.YourPackage/Private/Templates/Authenticate/Index.html'
+    templatePathAndFilename: 'resource://Acme.YourPackage/Private/Templates/Authentication/Index.html'
 ```
 
 Adjust the actual value in ``templatePathAndFilename`` to your needs and copy the [original template](Resources/Private/Templates/Authentication/Index.html)

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ add the following configuration there:
 
 ```yaml
 -
-  requestFilter: 'parentRequest.isPackage("Neos.Neos") && isFormat("html") && isPackage("Flowpack.Neos.FrontendLogin")'
+  requestFilter: 'parentRequest.isPackage("Neos.Neos") && isFormat("html") && isPackage("Flowpack.Neos.FrontendLogin") && isController("Authentication")'
   options:
     templatePathAndFilename: 'resource://Acme.YourPackage/Private/Templates/Authentication/Index.html'
 ```

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ add the following configuration there:
 
 ```yaml
 -
-  requestFilter: 'isPackage("Flowpack.Neos.FrontendLogin") && isController("Authentication") && isAction("index")'
+  requestFilter: 'parentRequest.isPackage("Neos.Neos") && isFormat("html") && isPackage("Flowpack.Neos.FrontendLogin")'
   options:
     templatePathAndFilename: 'resource://Acme.YourPackage/Private/Templates/Authentication/Index.html'
 ```


### PR DESCRIPTION
Fix the path for `templatePathAndFilename` to be the same as the the original template. The original template is located under `.../Authentication/Index.html` and **not** under `.../Authenticate/Index.html`, so as you copy the original template into your own package one might miss the difference (as I have done).

Also i have fixed the `requestFilter` in the Readme to be the same as the actual implemented `requestFilter` (otherwise the override of the template won't work)